### PR TITLE
Shell adminkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .vagrant
 Vagrantfile
+tests/.vagrant
 *.retry
 *.swp
 *.pyc
-tests/inventory.ini
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,6 @@
 * By default this role will remove the `AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys` entry in `sshd_config` so Administrators on the host do not use a shared key. This can be controlled with `opt_openssh_shared_admin_key` if you wish to use the shared location.
 * Added the `opt_openssh_default_shell`, `opt_openssh_default_shell_command_option`, and `opt_openssh_default_shell_escape_args` options to control the shell invocation options.
 
-# TODO:
-
-* Update `tests/custom_vars.yml` to check for the shared admin key presence and also for the change in the default shell
-* Update `tests/defaults.yml` to check the `sshd_config` to make sure the shared admin key is not there
-* Add a test for `opt_openssh_zip_file` in `tests/client.yml`
-* Test against Ansible `2.7`, `2.8`, and `2.9`
-
 
 ## v0.1.0 - 2018-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for win_openssh
 
-## v0.2.0 - TBD
+## v0.2.0 - 2019-12-27
 
 * Added the `opt_openssh_zip_file` and `opt_openssh_zip_remote_src` option to add another way to source the OpenSSH zip archive.
 * By default this role will remove the `AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys` entry in `sshd_config` so Administrators on the host do not use a shared key. This can be controlled with `opt_openssh_shared_admin_key` if you wish to use the shared location.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## v0.2.0 - TBD
 
-* TODO
+* Added the `opt_openssh_zip_file` and `opt_openssh_zip_remote_src` option to add another way to source the OpenSSH zip archive.
+* By default this role will remove the `AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys` entry in `sshd_config` so Administrators on the host do not use a shared key. This can be controlled with `opt_openssh_shared_admin_key` if you wish to use the shared location.
+* Added the `opt_openssh_default_shell`, `opt_openssh_default_shell_command_option`, and `opt_openssh_default_shell_escape_args` options to control the shell invocation options.
+
+# TODO:
+
+* Update `tests/custom_vars.yml` to check for the shared admin key presence and also for the change in the default shell
+* Update `tests/defaults.yml` to check the `sshd_config` to make sure the shared admin key is not there
+* Add a test for `opt_openssh_zip_file` in `tests/client.yml`
+* Test against Ansible `2.7`, `2.8`, and `2.9`
 
 
 ## v0.1.0 - 2018-10-31

--- a/README.md
+++ b/README.md
@@ -41,21 +41,30 @@ None, this role will run with the default options set.
 ### Optional Variables
 
 * `opt_openssh_architecture`: The Windows architecture, must be set to either `32` or `64` (default: `64`).
-* `opt_openssh_zip_file`: The full path of the OpenSSH zip file that need to be uploaded to the remote machine without downloading OpenSSH on remote machine.
 * `opt_openssh_firewall_profiles`: The firewall profiles to allow inbound SSH traffic (default: `domain,private`).
 * `opt_openssh_install_path`: The directory to install the OpenSSH binaries (default: `C:\Program Files\OpenSSH`).
-* `opt_openssh_pubkeys`: Either a string or list of strings to add to the user's `authorized_keys` file, by default no keys will be added.
+* `opt_openssh_pubkeys`: Either a string or list of strings to add to the user's `authorized_keys` file, by default no keys will be added. If `opt_openssh_shared_admin_key` is `True` then these keys will have no effect on the authentication for any Admin users.
 * `opt_openssh_setup_service`: Whether to install the sshd service components or just stick with the client executables (default: `True`).
 * `opt_openssh_skip_start`: Will not start the `sshd` and `ssh-agent` service and also not set to `auto start` (default: `False`).
 * `opt_openssh_temp_path`: The temporary directory to download the downloaded zip and extracted files (default: `C:\Windows\TEMP`).
 * `opt_openssh_url`: Sets the download location of the OpenSSH zip, if omitted then this will be sourced from the GitHub repository.
-* `opt_openssh_version`: Sets a specific version to download from GitHub, this is only valid when `opt_openssh_url` is not set (default: `latest`)
+* `opt_openssh_version`: Sets a specific version to download from GitHub, this is only valid when `opt_openssh_url` is not set (default: `latest`)i
+* `opt_openssh_zip_file`: The path to an OpenSSH zip release file that will be used to install OpenSSH. This will be used instead of `opt_openssh_url` if defined and `opt_openssh_zip_remote_src` controls whether the path is local to the controller or local to the Windows host.
+* `opt_openssh_zip_file`: The full path of the OpenSSH zip file that need to be uploaded to the remote machine without downloading OpenSSH on remote machine.
+* `opt_openssh_zip_remote_src`: (default: `False`)
 
 You can also customise the following sshd\_config values:
 
 * `opt_openssh_port`: Aligns to `Port`, the port the SSH service will listen on (default: `22`).
 * `opt_openssh_pubkey_auth`: Aligns to `PubkeyAuthentication`, whether the SSH service will allow authentication with SSH keys (default: `True`).
 * `opt_openssh_password_auth`: Aligns to `PasswordAuthentication`, whether the SSH service will allow authentication with passwords (default: `True`).
+* `opt_openssh_shared_admin_key`: Set to `True` to have Administrators used a shared authorization key at `__PROGRAMDATA__/ssh/administrators_authorized_keys`. Set to `False` to ensure `%USER_PROFILE%\.ssh\authorized_keys` is used for all users (default: `False`).
+
+You can customise the shell options to control how the sshd service starts a new shell:
+
+* `opt_openssh_default_shell`: Override the default shell set by the OpenSSH install. This should be the absolute path to an executable you want to run when starting an SSH session.
+* `opt_openssh_default_shell_command_option`: Set the arguments used when invoking the shell, this should not be adjusted in normal circumstances.
+* `opt_openssh_default_shell_escape_args`: Skip the automatic escaping arguments when invoking the shell.
 
 ### Output Variables
 
@@ -91,6 +100,13 @@ None
   - role: jborean93.win_openssh
     opt_openssh_setup_service: False
 ```
+
+
+## Testing
+
+To test this role, go to the [tests](tests) folder and run `vagrant up`. This
+will spin up a Windows Server 2019 host to test the role against. If the host
+is already online, running `vagrant provision` will rerun the tests.
 
 
 ## Backlog

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ None, this role will run with the default options set.
 * `opt_openssh_url`: Sets the download location of the OpenSSH zip, if omitted then this will be sourced from the GitHub repository.
 * `opt_openssh_version`: Sets a specific version to download from GitHub, this is only valid when `opt_openssh_url` is not set (default: `latest`)i
 * `opt_openssh_zip_file`: The path to an OpenSSH zip release file that will be used to install OpenSSH. This will be used instead of `opt_openssh_url` if defined and `opt_openssh_zip_remote_src` controls whether the path is local to the controller or local to the Windows host.
-* `opt_openssh_zip_file`: The full path of the OpenSSH zip file that need to be uploaded to the remote machine without downloading OpenSSH on remote machine.
 * `opt_openssh_zip_remote_src`: (default: `False`)
 
 You can also customise the following sshd\_config values:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ opt_openssh_port: 22
 opt_openssh_pubkey_auth: True
 opt_openssh_password_auth: True
 opt_openssh_setup_service: True
+opt_openssh_shared_admin_key: False
 opt_openssh_skip_start: False
 opt_openssh_temp_path: C:\Windows\TEMP
 opt_openssh_version: latest
+opt_openssh_zip_remote_src: False

--- a/library/win_sshd_config.ps1
+++ b/library/win_sshd_config.ps1
@@ -1,0 +1,72 @@
+#!powershell
+
+# Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+$params = Parse-Args $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name '_ansible_check_mode' -type 'bool' -default $false
+
+$path = Get-AnsibleParam -obj $params -name "path" -type "str" -failifempty $true
+$match_name = Get-AnsibleParam -obj $params -name "match_Name" -type "str" -failifempty $true
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
+$value = Get-AnsibleParam -obj $params -name "value" -type "str"
+
+$result = @{
+    changed = $false
+}
+
+$found = $false
+$in_match = $false
+$new_lines = Get-Content -LiteralPath $path | ForEach-Object -Process {
+    if ($_ -match "^\s*Match\s+(([\w]+)\s+([\w]+))") {
+        if ($Matches[1] -eq $match_name) {
+            $in_match = $true
+        } elseif ($in_match) {
+            # We are exiting the chosen match group, make sure the the name is set if a value is specified.
+            if (-not $found -and $value) {
+                "        $name $value"
+                ""  # Empty line to give some space between the next match.
+                $result.changed = $true
+                $found = $true
+            }
+            $in_match = $false
+        }
+    } elseif ($in_match -and $_ -match "^\s*([\w]+)\s+(.+)") {
+        if ($Matches[1] -eq $Name) {
+            $found = $true
+            if (-not $value) {
+                # We want to remove the key
+                $result.changed = $true
+                return
+            } elseif ($Matches[2] -ne $value) {
+                # The value is changed
+                "        $($Matches[1]) $value"
+                $found = $true
+                $result.changed = $true
+                return
+            }
+        }
+    }
+
+    $_
+}
+
+# Finally if the match was the last group we need to match sure the entry was found.
+if ($in_match) {
+    if (-not $found -and $value) {
+        $new_lines += "        $name $value"
+        $result.changed = $true
+    }
+} elseif (-not $found -and $value) {
+    # The match group wasn't even present so add that
+    $new_lines += @("", "Match $match_name", "        $name $value")
+    $result.changed = $true
+}
+
+if ($result.changed) {
+    Set-Content -LiteralPath $path -Value $new_lines -WhatIf:$check_mode
+}
+
+Exit-Json -obj $result

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -4,6 +4,7 @@
   win_copy:
     src: '{{ opt_openssh_zip_file }}'
     dest: '{{ opt_openssh_temp_path }}\OpenSSH-Win.zip'
+    remote_src: '{{ opt_openssh_zip_remote_src }}'
   when: opt_openssh_zip_file is defined
 
 - block:

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,11 +1,12 @@
 # downloads the Win32-OpenSSH zip and extracts to the specified directory
 ---
-- name: copy OpenSSH zip from Ansible controller
+- name: copy OpenSSH zip from {{ opt_openssh_zip_remote_src | ternary("local path", "Ansible controller") }}
   win_copy:
     src: '{{ opt_openssh_zip_file }}'
     dest: '{{ opt_openssh_temp_path }}\OpenSSH-Win.zip'
     remote_src: '{{ opt_openssh_zip_remote_src }}'
   when: opt_openssh_zip_file is defined
+  ignore_errors: '{{ ansible_check_mode }}'  # File may not exist when in check mode
 
 - block:
   - block:

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -33,6 +33,33 @@
   - not ansible_check_mode
   - opt_openssh_pubkeys is defined
 
+- name: set the default shell
+  win_regedit:
+    path: HKLM:\SOFTWARE\OpenSSH
+    name: DefaultShell
+    state: present
+    type: string
+    data: '{{ opt_openssh_default_shell }}'
+  when: opt_openssh_default_shell is defined
+
+- name: set the default shell command options
+  win_regedit:
+    path: HKLM:\SOFTWARE\OpenSSH
+    name: DefaultShellCommandOption
+    state: present
+    type: string
+    data: '{{ opt_openssh_default_shell_command_option }}'
+  when: opt_openssh_default_shell_command_option is defined
+
+- name: set the default shell escape arguments option
+  win_regedit:
+    path: HKLM:\SOFTWARE\OpenSSH
+    name: DefaultShellEscapeArguments
+    state: present
+    type: dword
+    data: '{{ (opt_openssh_default_shell_escape_args | bool) | ternary(1, 0) }}'
+  when: opt_openssh_default_shell_escape_args is defined
+
 - name: ensure sshd and ssh-agent service are set to start on boot
   win_service:
     name: '{{ item }}'

--- a/tasks/sshd_config.yml
+++ b/tasks/sshd_config.yml
@@ -24,6 +24,26 @@
     state: present
   ignore_errors: '{{ ansible_check_mode }}'
 
+- name: get the localised name for the Administrators group
+  win_shell: |
+    $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-32-544"
+    ($sid.Translate([System.Security.Principal.NTAccount]).Value -split "{{ '\\' }}")[1]
+  register: pri_openssh_admin_name_raw
+  check_mode: no
+  changed_when: False
+
+- name: process admin name from raw win_shell output
+  set_fact:
+    pri_openssh_admin_name: '{{ pri_openssh_admin_name_raw.stdout | trim }}'
+
+- name: set the admin_authorized_keys setting
+  win_sshd_config:
+    path: '{{ opt_openssh_install_path }}\sshd_config_default'
+    match_name: Group {{ pri_openssh_admin_name }}
+    name: AuthorizedKeysFile
+    value: '{{ (opt_openssh_shared_admin_key | bool) | ternary("__PROGRAMDATA__/ssh/administrators_authorized_keys", omit) }}'
+  ignore_errors: '{{ ansible_check_mode }}'
+
 - name: check if the server config directory already exists
   win_stat:
     path: C:\ProgramData\ssh

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+retry_files_enabled = False

--- a/tests/cleanup.yml
+++ b/tests/cleanup.yml
@@ -26,6 +26,14 @@
         state: absent
     when: openssh_installed is changed
 
+  - name: remove program files directories
+    win_file:
+      path: '{{ item }}'
+      state: absent
+    with_items:
+    - C:\Program Files\OpenSSH
+    - C:\OpenSSH
+
   - name: remove ssh ProgramData dir
     win_file:
       path: C:\ProgramData\ssh
@@ -34,6 +42,11 @@
   - name: remove the current user's .ssh folder
     win_file:
       path: '%USERPROFILE%\.ssh'
+      state: absent
+
+  - name: remove temp downloaded OpenSSH zip
+    win_file:
+      path: C:\Windows\TEMP\OpenSSH.zip
       state: absent
 
   - name: remove registry key

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -1,9 +1,17 @@
 ---
-- name: install with the defaults set
+- name: install client side components
   hosts: windows
   gather_facts: no
   vars:
+    opt_openssh_zip_file: C:\Windows\TEMP\OpenSSH.zip
+    opt_openssh_zip_remote_src: yes
     opt_openssh_setup_service: False
+
+  pre_tasks:
+  - name: download OpenSSH zip for zip file source
+    win_get_url:
+      url: https://github.com/PowerShell/Win32-OpenSSH/releases/download/v7.9.0.0p1-Beta/OpenSSH-Win64.zip
+      dest: C:\Windows\TEMP\OpenSSH.zip
 
   roles:
   - role: ../..

--- a/tests/custom_vars.yml
+++ b/tests/custom_vars.yml
@@ -8,8 +8,9 @@
     opt_openssh_pubkey_auth: False
     opt_openssh_password_auth: False
     opt_openssh_skip_start: True
-    opt_openssh_version: v7.7.1.0p1-Beta
+    opt_openssh_version: v7.9.0.0p1-Beta
     opt_openssh_pubkeys: mypubkey
+    opt_openssh_shared_admin_key: True
 
   roles:
   - role: ../..

--- a/tests/custom_vars.yml
+++ b/tests/custom_vars.yml
@@ -1,5 +1,5 @@
 ---
-- name: install with the defaults set
+- name: install with custom vars
   hosts: windows
   gather_facts: no
   vars:
@@ -10,6 +10,7 @@
     opt_openssh_skip_start: True
     opt_openssh_version: v7.9.0.0p1-Beta
     opt_openssh_pubkeys: mypubkey
+    opt_openssh_default_shell: powershell.exe
     opt_openssh_shared_admin_key: True
 
   roles:
@@ -74,6 +75,12 @@
     changed_when: False
     register: pubkeys_acl
 
+  - name: get default shell registry key value
+    win_reg_stat:
+      path: HKLM:\SOFTWARE\OpenSSH
+      name: DefaultShell
+    register: default_shell
+
   - name: assert results (check mode)
     assert:
       that:
@@ -104,10 +111,12 @@
       - '"PasswordAuthentication no" in sshd_config.stdout_lines'
       - '"#PasswordAuthentication yes" not in sshd_config.stdout_lines'
       - '"mypubkey" in auth_keys.stdout_lines'
+      - '"       AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys" in sshd_config.stdout_lines'
       - '"NT AUTHORITY\SYSTEM:(OI)(CI)(F)" in ssh_acl.stdout'
       - '"BUILTIN\Administrators:(OI)(CI)(F)" in ssh_acl.stdout'
       - 'ansible_user + ":(OI)(CI)(F)" in ssh_acl.stdout'
       - '"NT AUTHORITY\SYSTEM:(I)(F)" in pubkeys_acl.stdout'
       - '"BUILTIN\Administrators:(I)(F)" in pubkeys_acl.stdout'
       - 'ansible_user + ":(I)(F)" in pubkeys_acl.stdout'
+      - default_shell.value == 'powershell.exe'
     when: not ansible_check_mode

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -81,5 +81,6 @@
       - '"Port 22" in sshd_config.stdout_lines'
       - '"PubkeyAuthentication yes" in sshd_config.stdout_lines'
       - '"PasswordAuthentication yes" in sshd_config.stdout_lines'
+      - '"       AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys" not in sshd_config.stdout_lines'
       - sshd_config.stdout == sshd_config_service.stdout
     when: not ansible_check_mode

--- a/tests/inventory.ini
+++ b/tests/inventory.ini
@@ -1,0 +1,9 @@
+[windows]
+win  ansible_host=192.168.56.50
+
+[windows:vars]
+ansible_user=vagrant
+ansible_password=vagrant
+ansible_connection=psrp
+ansible_port=5985
+ansible_psrp_auth=ntlm

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -1,4 +1,6 @@
 ---
+- import_playbook: cleanup.yml
+
 - import_playbook: defaults.yml
 - import_playbook: cleanup.yml
 


### PR DESCRIPTION
Added

* Ability to set default shell and default shell options
* Expanded `opt_openssh_zip_file` to also work for remote_src files (on the Windows host)
* Added ability to control the behavour of the shared admin SSH key (default to it not being shared for consistency with OpenSSH)

Fixes https://github.com/jborean93/ansible-role-win_openssh/issues/1
Fixes https://github.com/jborean93/ansible-role-win_openssh/issues/3