### PR TITLE
Adding admin local name fix

### DIFF
--- a/tasks/sshd_config.yml
+++ b/tasks/sshd_config.yml
@@ -34,11 +34,10 @@
   ignore_errors: '{{ ansible_check_mode }}'
 
 - name: get the localised name for the Administrators group
-  win_shell: |
     $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-32-544"
-    ($sid.Translate([System.Security.Principal.NTAccount]).Value -split "{{ '\\' }}")[1]
-  register: pri_openssh_admin_name_raw
+    ($sid.Translate([System.Security.Principal.NTAccount]).Value -split '//')[1]
   check_mode: no
+  register: pri_openssh_admin_name_raw
   changed_when: False
 
 - name: process admin name from raw win_shell output

--- a/tasks/sshd_config.yml
+++ b/tasks/sshd_config.yml
@@ -34,8 +34,9 @@
   ignore_errors: '{{ ansible_check_mode }}'
 
 - name: get the localised name for the Administrators group
+    $bslash = [char]0x5C
     $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-32-544"
-    ($sid.Translate([System.Security.Principal.NTAccount]).Value -split '//')[1]
+    ($sid.Translate([System.Security.Principal.NTAccount]).Value -split "$bslash$bslash")[1]
   check_mode: no
   register: pri_openssh_admin_name_raw
   changed_when: False


### PR DESCRIPTION
There is an issue where the command used at:

https://github.com/jborean93/ansible-role-win_openssh/blob/3ae52fc70c15a38092e7ccbb89ba09b6de3d5afa/tasks/sshd_config.yml#L36-L42

causes the command to be output twice. No idea why because the task doesn't appear to suggest it would, but it does. The fix here was to simply remove the enclosing curly braces. I assume that Ansible no longer requires those curly braces to escape those characters any more and therefore it would be worthwhile to test with earlier versions of Ansible to ensure they are supported (if you intend on supported earlier versions). I am using Ansible 2.11.4.

Fixes https://github.com/jborean93/ansible-role-win_openssh/issues/16 