### PR TITLE
Bugfix - Restore Module Reference to sshd_config.yml

### DIFF
--- a/tasks/sshd_config.yml
+++ b/tasks/sshd_config.yml
@@ -34,6 +34,7 @@
   ignore_errors: '{{ ansible_check_mode }}'
 
 - name: get the localised name for the Administrators group
+  win_shell: |
     $bslash = [char]0x5C
     $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-32-544"
     ($sid.Translate([System.Security.Principal.NTAccount]).Value -split "$bslash$bslash")[1]


### PR DESCRIPTION
This bugfix restores the `win_shell` module reference to sshd_config.yml